### PR TITLE
commonjs module.exports is now added to rendered js if brunch setting modules.wrapper is set

### DIFF
--- a/lib/emblem-brunch.coffee
+++ b/lib/emblem-brunch.coffee
@@ -37,10 +37,18 @@ module.exports = class EmblemCompiler
           .replace(/^templates\//, '')
           .replace(/\.\w+$/, '')
         content = @window.Emblem.precompile @window.Ember.Handlebars, data
-        result = "Ember.TEMPLATES[#{JSON.stringify(path)}] = Ember.Handlebars.template(#{content});module.exports = module.id;"
+        result = "Ember.TEMPLATES[#{JSON.stringify(path)}] = Ember.Handlebars.template(#{content});"
+        switch @config.modules.wrapper
+          when 'commonjs'
+            result = "#{result}module.exports = module.id;"
+        result
       else
         content = @window.Emblem.precompile @window.Handlebars, data
-        result = "module.exports = Handlebars.template(#{content});"
+        result = "Handlebars.template(#{content});"
+        switch @config.modules.wrapper
+          when 'commonjs'
+            result = "module.exports = #{result}"
+        result
     catch err
       error = err
     finally


### PR DESCRIPTION
I found that if I modified the brunch settings in modules.wrapper to anything but the default of "commonjs", emblem-brunch would continue to append with "module.exports = ...". This was breaking my code when I wanted to turn off commonjs wrapping on my project. After I made this change, everything worked. 

I tested by disabling commonjs and enabling commonjs, and it seemed to work as expected. There is apparently one more type of wrapping that brunch provides called "amd". I didn't know how to add that, and there is also the option of creating your own wrapper. I didn't try to support that.

https://github.com/brunch/brunch/blob/stable/docs/config.md

Anyway, I thought this is at least a step in the right direction. Hope you find this useful.
